### PR TITLE
Suppress PSSA SecureString rule in examples

### DIFF
--- a/Examples/SCOM-MultiInstance-TP.ps1
+++ b/Examples/SCOM-MultiInstance-TP.ps1
@@ -1,5 +1,9 @@
 #requires -Version 5
 
+# Suppression of this PSSA rule allowed in examples
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
+param()
+
 Configuration OM
 {
     Import-DscResource -Module xCredSSP

--- a/Examples/SCOM-MultiInstance.ps1
+++ b/Examples/SCOM-MultiInstance.ps1
@@ -1,5 +1,9 @@
 #requires -Version 5
 
+# Suppression of this PSSA rule allowed in examples
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
+param()
+
 Configuration OM
 {
     Import-DscResource -Module xCredSSP

--- a/Examples/SCOM-SeperateSQL-TP.ps1
+++ b/Examples/SCOM-SeperateSQL-TP.ps1
@@ -1,5 +1,9 @@
 #requires -Version 5
 
+# Suppression of this PSSA rule allowed in examples
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
+param()
+
 Configuration OM
 {
     Import-DscResource -Module xCredSSP

--- a/Examples/SCOM-SeperateSQL.ps1
+++ b/Examples/SCOM-SeperateSQL.ps1
@@ -1,5 +1,9 @@
 #requires -Version 5
 
+# Suppression of this PSSA rule allowed in examples
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
+param()
+
 Configuration OM
 {
     Import-DscResource -Module xCredSSP

--- a/Examples/SCOM-SeperateSQLInstances-TP.ps1
+++ b/Examples/SCOM-SeperateSQLInstances-TP.ps1
@@ -1,5 +1,9 @@
 #requires -Version 5
 
+# Suppression of this PSSA rule allowed in examples
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
+param()
+
 Configuration OM
 {
     Import-DscResource -Module xCredSSP

--- a/Examples/SCOM-SeperateSQLInstances.ps1
+++ b/Examples/SCOM-SeperateSQLInstances.ps1
@@ -1,5 +1,9 @@
 #requires -Version 5
 
+# Suppression of this PSSA rule allowed in examples
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
+param()
+
 Configuration OM
 {
     Import-DscResource -Module xCredSSP

--- a/Examples/SCOM-SingleServer-TP.ps1
+++ b/Examples/SCOM-SingleServer-TP.ps1
@@ -1,5 +1,9 @@
 #requires -Version 5
 
+# Suppression of this PSSA rule allowed in examples
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
+param()
+
 Configuration OM
 {
     Import-DscResource -Module xCredSSP

--- a/Examples/SCOM-SingleServer.ps1
+++ b/Examples/SCOM-SingleServer.ps1
@@ -1,5 +1,9 @@
 #requires -Version 5
 
+# Suppression of this PSSA rule allowed in examples
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
+param()
+
 Configuration OM
 {
     Import-DscResource -Module xCredSSP


### PR DESCRIPTION
Resolves #3 

This is a fix for the current test failures blocking this module.
Suppresses the PSSA rule about avoiding ConvertTo-SecureString with -AsPlainText specified for examples. 
PSSA rule suppressions are allowed in examples.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xscom/4)

<!-- Reviewable:end -->
